### PR TITLE
feat: replace conventional commit head for equivalent word in PT-BR

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   },
   "dependencies": {
     "@octokit/types": "^8.0.0",
+    "@vitalets/google-translate-api": "^9.1.0",
     "axios": "^1.2.2",
+    "http-proxy-agent": "^5.0.0",
     "octokit": "^2.0.10",
     "puppeteer": "^19.4.1"
   }

--- a/src/github/get-commits.ts
+++ b/src/github/get-commits.ts
@@ -1,6 +1,8 @@
 import { Endpoints } from '@octokit/types';
+import { translate } from '@vitalets/google-translate-api';
 
 import * as fs from 'fs';
+import createHttpProxyAgent from 'http-proxy-agent';
 import { Octokit } from 'octokit';
 
 import config from '../../config';
@@ -22,15 +24,13 @@ const dateNow = (dateString: string): string => {
   return date.toISOString();
 };
 
-const simplifyCommit = (repo: string, _: Commit): SimpleCommit =>
-  //
+const simplifyCommit = (repo: string, _: Commit): SimpleCommit => ({
+  repo,
+  date: dateNow(_.commit.committer.date),
+  description: _.commit.message,
+  commit: _.html_url,
+});
 
-  ({
-    repo,
-    date: dateNow(_.commit.committer.date),
-    description: _.commit.message,
-    commit: _.html_url,
-  });
 const timeNumber = (time: string): number => Number(time.replace(':', ''));
 
 const timeFilter =
@@ -163,45 +163,51 @@ const joinInMD = (commits: GroupedCommit[]): string => {
     email = response.data.email;
   }
 
-  const promise = config.github.repositories.map(
-    async (repo): Promise<SimpleCommit[]> => {
-      let searchConfig: Endpoints['GET /repos/{owner}/{repo}/commits']['parameters'] =
-        {
-          owner: 'lubysoftware',
-          repo: repo.name,
-          author: email,
-          sha: repo.branch_sha,
-          per_page: 100,
-        };
+  const finalResponse: SimpleCommit[][] = [];
 
-      if (config.github.when) {
-        if (config.github.when.until)
-          searchConfig = { ...searchConfig, until: config.github.when.until };
-        if (config.github.when.since)
-          searchConfig = { ...searchConfig, since: config.github.when.since };
-      }
+  for (const repo of config.github.repositories) {
+    let searchConfig: Endpoints['GET /repos/{owner}/{repo}/commits']['parameters'] =
+      {
+        owner: 'lubysoftware',
+        repo: repo.name,
+        author: email,
+        sha: repo.branch_sha,
+        per_page: 100,
+      };
 
-      const response = await octokit.request(
-        'GET /repos/{owner}/{repo}/commits',
-        searchConfig
+    if (config.github.when) {
+      if (config.github.when.until)
+        searchConfig = { ...searchConfig, until: config.github.when.until };
+      if (config.github.when.since)
+        searchConfig = { ...searchConfig, since: config.github.when.since };
+    }
+
+    const response = await octokit.request(
+      'GET /repos/{owner}/{repo}/commits',
+      searchConfig
+    );
+
+    const simplified: SimpleCommit[] = [];
+
+    for (const data of response.data) {
+      data.commit.message = data.commit.message.replace(
+        /feat|fix|docs|style|refactor|chore|test|merge/gim,
+        (matched) => conventionalCommitsHashmap[matched]
       );
 
-      const simplified: SimpleCommit[] = response.data.map((data) => {
-        data.commit.message = data.commit.message.replace(
-          /feat|fix|docs|style|refactor|chore|test|merge/gim,
-          (matched) => conventionalCommitsHashmap[matched]
-        );
-
-        return simplifyCommit(repo.name, data);
+      const { text } = await translate(data.commit.message, {
+        to: 'pt-br',
       });
 
-      return removeMerge(simplified);
+      data.commit.message = text;
+
+      simplified.push(simplifyCommit(repo.name, data));
     }
-  );
 
-  const response = await Promise.all(promise);
+    finalResponse.push(removeMerge(simplified));
+  }
 
-  const joined = joinLists(response);
+  const joined = joinLists(finalResponse);
 
   // sort by date
   joined.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));

--- a/src/github/get-commits.ts
+++ b/src/github/get-commits.ts
@@ -12,6 +12,7 @@ import {
   SimpleCommit,
   TimeGroupedCommit,
 } from '../types';
+import { conventionalCommitsHashmap } from '../utils';
 
 const dateNow = (dateString: string): string => {
   const date = new Date(dateString);
@@ -21,13 +22,15 @@ const dateNow = (dateString: string): string => {
   return date.toISOString();
 };
 
-const simplifyCommit = (repo: string, _: Commit): SimpleCommit => ({
-  repo,
-  date: dateNow(_.commit.committer.date),
-  description: _.commit.message,
-  commit: _.html_url,
-});
+const simplifyCommit = (repo: string, _: Commit): SimpleCommit =>
+  //
 
+  ({
+    repo,
+    date: dateNow(_.commit.committer.date),
+    description: _.commit.message,
+    commit: _.html_url,
+  });
 const timeNumber = (time: string): number => Number(time.replace(':', ''));
 
 const timeFilter =
@@ -183,9 +186,14 @@ const joinInMD = (commits: GroupedCommit[]): string => {
         searchConfig
       );
 
-      const simplified: SimpleCommit[] = response.data.map((data) =>
-        simplifyCommit(repo.name, data)
-      );
+      const simplified: SimpleCommit[] = response.data.map((data) => {
+        data.commit.message = data.commit.message.replace(
+          /feat|fix|docs|style|refactor|chore|test|merge/gim,
+          (matched) => conventionalCommitsHashmap[matched]
+        );
+
+        return simplifyCommit(repo.name, data);
+      });
 
       return removeMerge(simplified);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,8 @@ import config from '../config';
 import { IAppointments } from './types';
 
 const commonData = {
-  client: '8231',
-  project: '18548',
+  client: '15',
+  project: '50',
   category: '1',
   notMonetize: false,
 };
@@ -35,3 +35,9 @@ export const conventionalCommitsHashmap = {
   test: 'Testes automatizados',
   merge: 'Review de Pull Request',
 };
+
+export function reformatDate(dateStr: string) {
+  const dArr = dateStr.split('-'); // ex input: "2010-01-18"
+
+  return dArr[2] + '/' + dArr[1] + '/' + dArr[0]; // ex output: "18/01/10"
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,3 +24,14 @@ export const make = (
       ...commonData,
     })
   );
+
+export const conventionalCommitsHashmap = {
+  feat: 'Desenvolvimento de feature',
+  fix: 'Correção/manutenção de bug',
+  docs: 'Documentação',
+  style: 'Formatação de estilos',
+  refactor: 'Refatoração',
+  chore: 'Outras alterações',
+  test: 'Testes automatizados',
+  merge: 'Review de Pull Request',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,6 +328,11 @@
     "@octokit/webhooks-types" "6.7.0"
     aggregate-error "^3.1.0"
 
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -357,6 +362,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/btoa-lite/-/btoa-lite-1.0.0.tgz#e190a5a548e0b348adb0df9ac7fa5f1151c7cca4"
   integrity sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg==
+
+"@types/http-errors@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.8.2.tgz#7315b4c4c54f82d13fa61c228ec5c2ea5cc9e0e1"
+  integrity sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==
 
 "@types/json-schema@^7.0.9":
   version "7.0.11"
@@ -484,6 +494,15 @@
   dependencies:
     "@typescript-eslint/types" "5.45.0"
     eslint-visitor-keys "^3.3.0"
+
+"@vitalets/google-translate-api@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@vitalets/google-translate-api/-/google-translate-api-9.1.0.tgz#5a754d379553cc3b7ad741635c2349a6ae60c806"
+  integrity sha512-iA36eHfypNaYOHUjVoYcQ9Ro98WXHdBDgKNlWqn4MN4PA/R7bgccH4KlLWwuem5FjCSlRev27ZTUtyp/axgOVQ==
+  dependencies:
+    "@types/http-errors" "^1.8.2"
+    http-errors "^2.0.0"
+    node-fetch "^2.6.7"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -788,6 +807,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
@@ -1198,6 +1222,26 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+http-errors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    toidentifier "1.0.1"
+
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
@@ -1242,7 +1286,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1763,6 +1807,11 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -1792,6 +1841,11 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -1878,6 +1932,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tr46@~0.0.3:
   version "0.0.3"


### PR DESCRIPTION
Através de uso de RegExp e um hashmap, troquei o head do commit por uma palavra equivalente em português

```ts
export const conventionalCommitsHashmap = {
  feat: 'Desenvolvimento de feature',
  fix: 'Correção/manutenção de bug',
  docs: 'Documentação',
  style: 'Formatação de estilos',
  refactor: 'Refatoração',
  chore: 'Outras alterações',
  test: 'Testes automatizados',
  merge: 'Review de Pull Request',
};
```